### PR TITLE
Compatibility with kdrfc.

### DIFF
--- a/draft-chroboczek-int-v4-via-v6.md
+++ b/draft-chroboczek-int-v4-via-v6.md
@@ -3,6 +3,7 @@ title: "IPv4 routes with an IPv6 next hop"
 abbrev: "v4-via-v6"
 category: std
 submissiontype: IETF
+ipr: trust200902
 
 docname: draft-chroboczek-int-v4-via-v6-latest
 v: 3
@@ -33,15 +34,15 @@ author:
     email: warren@kumari.net
 
 normative:
-  rfc7600:
+  RFC7600:
 
 informative:
-  rfc4861:
-  rfc0826:
-  rfc7404:
-  rfc0792:
-  rfc1191:
-  rfc4821:
+  RFC4861:
+  RFC0826:
+  RFC7404:
+  RFC0792:
+  RFC1191:
+  RFC4821:
   IANA-IPV4-REGISTRY:
     title: IANA IPv4 Address Registry
     author:


### PR DESCRIPTION
These changes appear to be necessary in order to compile the draft
on my system.  Note in particular that my version of xml2rfc appears
to require an "ipr" attribute -- I've picked the value "trust200902"
more or less at random.
